### PR TITLE
Retry socket timeouts and bump patch version

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                beefheart
-version:             0.2.5.0
+version:             0.2.6.0
 license:             Apache
 license-file:        LICENSE
 author:              "Elastic Infra Team"

--- a/src/Beefheart/Internal.hs
+++ b/src/Beefheart/Internal.hs
@@ -103,6 +103,11 @@ metricsRunner indexNamer service = katipAddNamespace "metrics" $ do
         logLocM WarningS . ls $ "Encountered connection timeout fetching metrics for '"
           <> serviceName <> "'. Retry attempt: " <> tshow (rsIterNumber retryStatus)
         return True
+      -- These sorts of exceptions often indicate a reset socket. Fine to retry.
+      (VanillaHttpException (HTTP.HttpExceptionRequest _request (HTTP.InternalException e))) -> do
+        logLocM WarningS . ls $ "Exception " <> tshow e <> " encountered for service '"
+          <> serviceName <> "'. Retry attempt: " <> tshow (rsIterNumber retryStatus)
+        return True
       e -> do
         logLocM WarningS . ls $ "Encountered a non-recoverable error. Bailing out: " <> tshow e
         return False


### PR DESCRIPTION
Observed some uncaught exceptions in production logs, so popped in this exception to the handler retry logic.